### PR TITLE
fix: add library to handle cors allowed origins

### DIFF
--- a/composeexample/settings.py
+++ b/composeexample/settings.py
@@ -32,6 +32,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -43,6 +44,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -129,3 +131,7 @@ STATIC_URL = '/static/'
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:3000',
+]

--- a/recipelib/api_views/user.py
+++ b/recipelib/api_views/user.py
@@ -23,7 +23,6 @@ class UserSignup(View):
             user.set_password(data.get('password'))
             user.save()
 
-            headers = {'content-type': 'application/json'}
             return JsonResponse(UserSerializer(user).data, safe=False, status=201)
         except Exception as err:
             print(err)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django>=3.0,<4.0
 psycopg2>=2.8
 requests>=2.20.0
 djangorestframework>=3.9.0
+django-cors-headers>=3.11.0


### PR DESCRIPTION
## Changes
Arreglar problema de no tener el header en las respuestas de la API con los dominios permitidos

## Detalle
- Instalar la librería `django-cors-headers`
- Agregar las configuraciones necesarias para los dominios permitidos
- Eliminar línea que no se utilizaba en `UserSignup`
