### PR TITLE
Chf 7/GitHub actions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,30 @@
+name: Django CI
+
+on:
+  push:
+    branches: [ CHF-7/github-actions ]
+  pull_request:
+    branches: [ develop, main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run Tests
+      run: |
+        python manage.py test

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -2,7 +2,7 @@ name: Django CI
 
 on:
   push:
-    branches: [ CHF-7/github-actions ]
+    branches: [ develop, main ]
   pull_request:
     branches: [ develop, main ]
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,5 +19,3 @@ jobs:
       run: docker-compose up -d
     - name: Run Tests
       run: docker-compose run web python manage.py test
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,3 +19,5 @@ jobs:
       run: docker-compose up -d
     - name: Run Tests
       run: docker-compose run web python manage.py test
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,30 @@
+name: Django CI
+
+on:
+  push:
+    branches: [ CHF-7/github-actions ]
+  pull_request:
+    branches: [ develop, main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.10]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run Tests
+      run: |
+        python manage.py test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,4 +14,16 @@ repos:
     rev: 3.9.2
     hooks:
     - id: flake8
+
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: 'false'
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "2.4"
    
 services:
   db:


### PR DESCRIPTION
## Descripción General
Se crea un workflow `deployment.yml` para el uso de github actions, el que crea un contenedor para el proyecto, ejecuta los tests y finalmente corre los pre-commits, para correr black, issort y flake8.

## Probar
Si bien para probar los cambios es medio engorroso, se puede hacer creando una rama a partir de esta, cambiar el nombre de las branches `main` y `develop` por el nombre de la rama nueva, hacer push y finalmente ir a la sección de actions y ver todo el proceso.

## Tarjeta en Jira
[CHF-7](https://tfflores.atlassian.net/browse/CHF-7)