### PR TITLE
feat(get_user_by_id): add follow info to GET user

### DIFF
--- a/recipelib/operations/users/show.py
+++ b/recipelib/operations/users/show.py
@@ -24,10 +24,14 @@ def show(request):
         )
 
 
-def show_by_id(_, user_id):
+def show_by_id(request, user_id):
     try:
         user = User.objects.get(pk=user_id)
-        return JsonResponse(UserSerializer(user).data, safe=False, status=201)
+        return JsonResponse(
+            UserSerializer(user, context={"request": request}).data,
+            safe=False,
+            status=201,
+        )
     except Exception as error:
         print(error)
         return JsonResponse(

--- a/recipelib/serializers.py
+++ b/recipelib/serializers.py
@@ -65,11 +65,14 @@ class UserSerializer(ModelSerializer):
     def get_is_following(self, obj):
         if not self.context.get("request", None):
             return None
-        if self.context.get("request").user.is_authenticated:
+        current_user = self.context.get("request").user
+        if current_user.is_authenticated:
+            if current_user.id == obj.id:
+                return None
             return (
                 obj.profile.followers.all()
                 .values_list("user", flat=True)
-                .filter(user=self.context["request"].user)
+                .filter(user=current_user)
                 .exists()
             )
         return None

--- a/recipelib/serializers.py
+++ b/recipelib/serializers.py
@@ -31,6 +31,9 @@ class FollowingSerializer(ModelSerializer):
 class UserSerializer(ModelSerializer):
     picture_url = serializers.SerializerMethodField("get_picture_url")
     description = serializers.SerializerMethodField("get_description")
+    followers = serializers.SerializerMethodField("get_followers")
+    following = serializers.SerializerMethodField("get_following")
+    is_following = serializers.SerializerMethodField("get_is_following")
 
     class Meta:
         model = User
@@ -42,6 +45,9 @@ class UserSerializer(ModelSerializer):
             "last_name",
             "description",
             "picture_url",
+            "followers",
+            "following",
+            "is_following",
         )
 
     def get_picture_url(self, obj):
@@ -49,6 +55,24 @@ class UserSerializer(ModelSerializer):
 
     def get_description(self, obj):
         return ProfileSerializer(obj.profile).data.get("description")
+
+    def get_followers(self, obj):
+        return list(obj.profile.followers.all().values_list("user", flat=True))
+
+    def get_following(self, obj):
+        return list(obj.profile.following.all().values_list("user", flat=True))
+
+    def get_is_following(self, obj):
+        if not self.context.get("request", None):
+            return None
+        if self.context.get("request").user.is_authenticated:
+            return (
+                obj.profile.followers.all()
+                .values_list("user", flat=True)
+                .filter(user=self.context["request"].user)
+                .exists()
+            )
+        return None
 
 
 class ProfileSerializer(ModelSerializer):


### PR DESCRIPTION
# Descripción general
Se agregó la info de a quien sigue, quien lo sigue y si el usuario actual lo sigue o no.

# Detalles
- Se agregaron los campos `followers`, `following` y `is_following` al serializador de User
- `followers` es una lista de los id de quien sigue al usuario
- `following` es una lista de los id de los seguidos por el usuario
- `is_following` es un booleano que indica si el current_user sigue o no a este usuario, en caso de que el GET se haga a sí mismo o no haya iniciado sesión retornará null

# Probar
 Esta pensado para usarlo en el endpoint `http://localhost:8000/api/users/show/<user_id>/`

# Tarjeta en Jira
[CHF-61](https://tfflores.atlassian.net/jira/software/projects/CHF/boards/1?selectedIssue=CHF-61)