### PR TITLE
[CHF-63] Filter hidden recipes

### DIFF
--- a/recipelib/operations/recipes/recipe_actions.py
+++ b/recipelib/operations/recipes/recipe_actions.py
@@ -236,7 +236,11 @@ def get_self_recipes(req):
 def get_chef_recipes(_, user_id):
     try:
         chef = User.objects.get(pk=user_id)
-        recipes = Recipe.objects.filter(user=chef).order_by("-created_at")
+        recipes = (
+            Recipe.objects.filter(private=False)
+            .filter(user=chef)
+            .order_by("-created_at")
+        )
         return JsonResponse(
             RecipeSerializer(recipes, many=True).data,
             safe=False,

--- a/recipelib/operations/recipes/recipe_actions.py
+++ b/recipelib/operations/recipes/recipe_actions.py
@@ -281,7 +281,8 @@ def get_feed(req, following=False):
             order_list = ["-created_at", "-popularity"]
 
         recipes = (
-            Recipe.objects.filter(~Q(user=req.user))
+            Recipe.objects.filter(private=False)
+            .filter(~Q(user=req.user))
             .annotate(
                 likes=Count(
                     Case(


### PR DESCRIPTION
## Descripción general

Este PR añade filtro para que las recetas privadas no sean visibles en el feed y en los perfiles de terceros.

## Probar los cambios

En `http://localhost:8000/api/recipes/chef/CHEF_ID/` no se incluirán las recetas del chef de id CHEF_ID que sean privadas. En `http://localhost:8000/api/recipes/feed/` no se incluirá ninguna receta privada.

## Tarjeta en Jira

[CHF-63](https://tfflores.atlassian.net/browse/CHF-63)
